### PR TITLE
add V2 in the module MagazineLuizaRewards

### DIFF
--- a/lib/magazine_luiza_rewards.rb
+++ b/lib/magazine_luiza_rewards.rb
@@ -61,7 +61,7 @@ require_relative 'magazine_luiza_rewards/models/shipping_contact'
 require_relative 'magazine_luiza_rewards/models/payment_info'
 require_relative 'magazine_luiza_rewards/models/order_request'
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   def self.root
     File.expand_path '..', __dir__
   end

--- a/lib/magazine_luiza_rewards/api/authentication.rb
+++ b/lib/magazine_luiza_rewards/api/authentication.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   module Api
     class Authentication < Base
       def generate_token(username, password)

--- a/lib/magazine_luiza_rewards/api/base.rb
+++ b/lib/magazine_luiza_rewards/api/base.rb
@@ -2,13 +2,13 @@
 
 require 'forwardable'
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   module Api
     class Base
       extend Forwardable
       include Exceptions
 
-      def initialize(client = MagazineLuizaRewards::Client.new)
+      def initialize(client = MagazineLuizaRewardsV2::Client.new)
         @client = client
       end
 

--- a/lib/magazine_luiza_rewards/api/carts.rb
+++ b/lib/magazine_luiza_rewards/api/carts.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   module Api
     class Carts < Base
       def create(items = [])

--- a/lib/magazine_luiza_rewards/api/categories.rb
+++ b/lib/magazine_luiza_rewards/api/categories.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   module Api
     class Categories < Base
       def categories

--- a/lib/magazine_luiza_rewards/api/customers.rb
+++ b/lib/magazine_luiza_rewards/api/customers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   module Api
     class Customers < Base
       def create(customer)

--- a/lib/magazine_luiza_rewards/api/freight.rb
+++ b/lib/magazine_luiza_rewards/api/freight.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   module Api
     class Freight < Base
       def calculate(zip_code, cart_id)

--- a/lib/magazine_luiza_rewards/api/orders.rb
+++ b/lib/magazine_luiza_rewards/api/orders.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   module Api
     class Orders < Base
       def create(order_request)

--- a/lib/magazine_luiza_rewards/api/products.rb
+++ b/lib/magazine_luiza_rewards/api/products.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   module Api
     class Products < Base
       def products(limit = 10, page = 1, filters = {})

--- a/lib/magazine_luiza_rewards/client.rb
+++ b/lib/magazine_luiza_rewards/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class Client
     extend Forwardable
 

--- a/lib/magazine_luiza_rewards/exceptions.rb
+++ b/lib/magazine_luiza_rewards/exceptions.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   module Exceptions
     APIExceptionError = Class.new(StandardError)
     BadRequestError = Class.new(APIExceptionError)

--- a/lib/magazine_luiza_rewards/models/address.rb
+++ b/lib/magazine_luiza_rewards/models/address.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class Address < Dry::Struct
     attribute :zip_code, Types::Coercible::String
     attribute :street, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/address_add.rb
+++ b/lib/magazine_luiza_rewards/models/address_add.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class AddressAdd < Dry::Struct
     attribute :alias, Types::Coercible::String
     attribute :name, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/bank_slip.rb
+++ b/lib/magazine_luiza_rewards/models/bank_slip.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class BankSlip < Dry::Struct
     attribute :our_number, Types::Coercible::String
     attribute :doc_number, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/best_price.rb
+++ b/lib/magazine_luiza_rewards/models/best_price.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class BestPrice < Dry::Struct
     attribute? :discount, Types::Coercible::String
     attribute? :payment_method_description, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/calculated_freight.rb
+++ b/lib/magazine_luiza_rewards/models/calculated_freight.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class CalculatedFreight < Dry::Struct
     attribute :disclaimers, Types::Array.of(Types::Coercible::String)
     attribute :deliveries, Types::Array.of(Delivery)

--- a/lib/magazine_luiza_rewards/models/cart.rb
+++ b/lib/magazine_luiza_rewards/models/cart.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class Cart < Dry::Struct
     attribute :id, Types::Coercible::String
     attribute? :items, Types::Array.of(CartItem)

--- a/lib/magazine_luiza_rewards/models/cart_item.rb
+++ b/lib/magazine_luiza_rewards/models/cart_item.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class CartItem < Dry::Struct
     attribute? :list_price, Types::Coercible::Decimal
     attribute? :price, Types::Coercible::Decimal

--- a/lib/magazine_luiza_rewards/models/category.rb
+++ b/lib/magazine_luiza_rewards/models/category.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class Category < Dry::Struct
     attribute :id, Types::Coercible::String
     attribute :name, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/customer.rb
+++ b/lib/magazine_luiza_rewards/models/customer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class Customer < Dry::Struct
     attribute :name, Types::Coercible::String
     attribute :email, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/delivery.rb
+++ b/lib/magazine_luiza_rewards/models/delivery.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class Delivery < Dry::Struct
     attribute :id, Types::Coercible::String
     attribute :status, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/delivery_item.rb
+++ b/lib/magazine_luiza_rewards/models/delivery_item.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class DeliveryItem < Dry::Struct
     attribute :sku, Types::Coercible::String
     attribute :quantity, Types::Coercible::Decimal

--- a/lib/magazine_luiza_rewards/models/delivery_modality.rb
+++ b/lib/magazine_luiza_rewards/models/delivery_modality.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class DeliveryModality < Dry::Struct
     attribute :id, Types::Coercible::String
     attribute :name, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/delivery_parameters.rb
+++ b/lib/magazine_luiza_rewards/models/delivery_parameters.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class DeliveryParameters < Dry::Struct
     attribute :provider, Types::Coercible::String
     attribute :recipient_name, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/delivery_type.rb
+++ b/lib/magazine_luiza_rewards/models/delivery_type.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class DeliveryType < Dry::Struct
     attribute :time, Types::Integer
     attribute :type, Types::String

--- a/lib/magazine_luiza_rewards/models/estimated_freight.rb
+++ b/lib/magazine_luiza_rewards/models/estimated_freight.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class EstimatedFreight < Dry::Struct
     attribute :sku, Types::String
     attribute :seller, Types::String

--- a/lib/magazine_luiza_rewards/models/factsheet.rb
+++ b/lib/magazine_luiza_rewards/models/factsheet.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class Factsheet < Dry::Struct
     attribute? :display_name, Types::Coercible::String
     attribute? :elements, Types::Array.of(FactsheetElement)

--- a/lib/magazine_luiza_rewards/models/factsheet_element.rb
+++ b/lib/magazine_luiza_rewards/models/factsheet_element.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class FactsheetElement < Dry::Struct
     attribute? :elements, Types::Array.of(FactsheetElementElement)
     attribute? :key_name, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/factsheet_element_element.rb
+++ b/lib/magazine_luiza_rewards/models/factsheet_element_element.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class FactsheetElementElement < Dry::Struct
     attribute? :is_html, Types::Bool
     attribute? :value, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/installment_plans.rb
+++ b/lib/magazine_luiza_rewards/models/installment_plans.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class InstallmentPlans < Dry::Struct
     attribute :discount, Types::Coercible::String
     attribute :discount_amount, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/modality.rb
+++ b/lib/magazine_luiza_rewards/models/modality.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class Modality < Dry::Struct
     attribute :id, Types::Coercible::String
     attribute :type, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/order.rb
+++ b/lib/magazine_luiza_rewards/models/order.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class Order < Dry::Struct
     attribute :customer_id, Types::Coercible::String
     attribute :shipping do

--- a/lib/magazine_luiza_rewards/models/order_item.rb
+++ b/lib/magazine_luiza_rewards/models/order_item.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class OrderItem < Dry::Struct
     attribute :sku, Types::Coercible::String
     attribute :seller, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/order_payment.rb
+++ b/lib/magazine_luiza_rewards/models/order_payment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class OrderPayment < Dry::Struct
     attribute :payment_method_id, Types::Coercible::String
     attribute :payment_method_name, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/order_request.rb
+++ b/lib/magazine_luiza_rewards/models/order_request.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class OrderRequest < Dry::Struct
     attribute :cart_id, Types::Coercible::String
     attribute :customer_ip_address, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/package.rb
+++ b/lib/magazine_luiza_rewards/models/package.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class Package < Dry::Struct
     attribute :price, Types::Coercible::Decimal
     attribute :delivery_time, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/package_item.rb
+++ b/lib/magazine_luiza_rewards/models/package_item.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class PackageItem < Dry::Struct
     attribute :sku, Types::Coercible::String
     attribute :bundle_sku, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/partial_update_deliveries.rb
+++ b/lib/magazine_luiza_rewards/models/partial_update_deliveries.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class PartialUpdateDeliveries < Dry::Struct
     attribute :id, Types::Coercible::String
     attribute :modality, Modality

--- a/lib/magazine_luiza_rewards/models/payment_info.rb
+++ b/lib/magazine_luiza_rewards/models/payment_info.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class PaymentInfo < Dry::Struct
     attribute :encrypted_credit_card, Types::Coercible::String
   end

--- a/lib/magazine_luiza_rewards/models/payment_methods.rb
+++ b/lib/magazine_luiza_rewards/models/payment_methods.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class PaymentMethods < Dry::Struct
     attribute? :id, Types::Coercible::String
     attribute? :description, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/phone.rb
+++ b/lib/magazine_luiza_rewards/models/phone.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class Phone < Dry::Struct
     attribute :area_code, Types::Coercible::String
     attribute :number, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/pix.rb
+++ b/lib/magazine_luiza_rewards/models/pix.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class Pix < Dry::Struct
     attribute :image_base64, Types::Coercible::String
     attribute :link, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/product.rb
+++ b/lib/magazine_luiza_rewards/models/product.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class Product < Dry::Struct
     attribute? :active, Types::Bool
     attribute? :attributes, Types::Array.of(ProductAttribute)

--- a/lib/magazine_luiza_rewards/models/product_attribute.rb
+++ b/lib/magazine_luiza_rewards/models/product_attribute.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class ProductAttribute < Dry::Struct
     attribute :type, Types::Coercible::String
     attribute :value, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/product_bundle.rb
+++ b/lib/magazine_luiza_rewards/models/product_bundle.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class ProductBundle < Dry::Struct
     attribute :brand, Types::Coercible::String
     attribute :price, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/product_dimension.rb
+++ b/lib/magazine_luiza_rewards/models/product_dimension.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class ProductDimension < Dry::Struct
     attribute :depth, Types::Coercible::Float
     attribute :height, Types::Coercible::Float

--- a/lib/magazine_luiza_rewards/models/product_price.rb
+++ b/lib/magazine_luiza_rewards/models/product_price.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class ProductPrice < Dry::Struct
     attribute :sku, Types::Coercible::String
     attribute :seller_id, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/shipping_contact.rb
+++ b/lib/magazine_luiza_rewards/models/shipping_contact.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class ShippingContact < Dry::Struct
     attribute :phone_ddd, Types::Coercible::String
     attribute :phone_number, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/shipping_time_response.rb
+++ b/lib/magazine_luiza_rewards/models/shipping_time_response.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class ShippingTimeResponse < Dry::Struct
     attribute :unit, Types::Coercible::String
     attribute :min_value, Types::Coercible::Decimal

--- a/lib/magazine_luiza_rewards/models/sub_category.rb
+++ b/lib/magazine_luiza_rewards/models/sub_category.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class SubCategory < Dry::Struct
     attribute :id, Types::Coercible::String
     attribute :name, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/models/token_info.rb
+++ b/lib/magazine_luiza_rewards/models/token_info.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class TokenInfo < Dry::Struct
     attribute :access_token, Types::Coercible::String
     attribute :expires_in, Types::Coercible::Integer

--- a/lib/magazine_luiza_rewards/models/unavailable_delivery.rb
+++ b/lib/magazine_luiza_rewards/models/unavailable_delivery.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   class UnavailableDelivery < Dry::Struct
     attribute :id, Types::Coercible::String
     attribute :status, Types::Coercible::String

--- a/lib/magazine_luiza_rewards/version.rb
+++ b/lib/magazine_luiza_rewards/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   VERSION = '0.1.0'
 end

--- a/magazine_luiza_rewards.gemspec
+++ b/magazine_luiza_rewards.gemspec
@@ -4,7 +4,7 @@ require_relative 'lib/magazine_luiza_rewards/version'
 
 Gem::Specification.new do |spec|
   spec.name = 'magazine_luiza_rewards'
-  spec.version = MagazineLuizaRewards::VERSION
+  spec.version = MagazineLuizaRewardsV2::VERSION
   spec.authors = ['Ronaldo de Sousa Araujo']
   spec.email = ['contato@ronaldoaraujo.eti.br']
 

--- a/sig/magazine_luiza_rewards.rbs
+++ b/sig/magazine_luiza_rewards.rbs
@@ -1,4 +1,4 @@
-module MagazineLuizaRewards
+module MagazineLuizaRewardsV2
   VERSION: String
   # See the writing guide of rbs: https://github.com/ruby/rbs#guides
 end

--- a/spec/lib/magazine_luiza_rewards/api/authentication_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/api/authentication_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Api::Authentication do
+RSpec.describe MagazineLuizaRewardsV2::Api::Authentication do
   subject(:authentication) { described_class.new }
 
   describe '#generate_token' do
@@ -34,7 +34,7 @@ RSpec.describe MagazineLuizaRewards::Api::Authentication do
     end
 
     context 'when successful', vcr: { cassette_name: 'success_authentication_request' } do
-      it { is_expected.to be_a(MagazineLuizaRewards::TokenInfo) }
+      it { is_expected.to be_a(MagazineLuizaRewardsV2::TokenInfo) }
       it { expect(token_info.access_token).to be_a(String) }
       it { expect(token_info.expires_in).to be_a(Integer) }
       it { expect(token_info.access_token).to eq(expected_token) }
@@ -45,7 +45,7 @@ RSpec.describe MagazineLuizaRewards::Api::Authentication do
       let(:username) { 'wrong_username' }
 
       it do
-        expect { token_info }.to raise_error(MagazineLuizaRewards::Exceptions::UnauthorizedError)
+        expect { token_info }.to raise_error(MagazineLuizaRewardsV2::Exceptions::UnauthorizedError)
       end
     end
   end

--- a/spec/lib/magazine_luiza_rewards/api/carts_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/api/carts_spec.rb
@@ -2,22 +2,22 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Api::Carts do
+RSpec.describe MagazineLuizaRewardsV2::Api::Carts do
   subject(:api_carts) { described_class.new(client) }
 
   let(:token) { 'fake-token' }
-  let(:client) { MagazineLuizaRewards::Client.new(token) }
+  let(:client) { MagazineLuizaRewardsV2::Client.new(token) }
 
   describe '#create' do
     subject(:cart) { api_carts.create(items) }
 
     let(:sku) { '200487300' }
     let(:items) do
-      [MagazineLuizaRewards::CartItem.new(sku: sku, seller: 'magazineluiza', quantity: 1)]
+      [MagazineLuizaRewardsV2::CartItem.new(sku: sku, seller: 'magazineluiza', quantity: 1)]
     end
 
     context 'when successfull', vcr: { cassette_name: 'carts/successful' } do
-      it { expect(cart).to be_a(MagazineLuizaRewards::Cart) }
+      it { expect(cart).to be_a(MagazineLuizaRewardsV2::Cart) }
       it { expect(cart.items.first.sku).to eq('200487300') }
       it { expect(cart.items.first.seller).to eq('magazineluiza') }
       it { expect(cart.items.first.quantity).to eq(1) }
@@ -29,7 +29,7 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
       let(:sku) { 'invalid' }
 
       it do
-        expect { cart }.to raise_error(MagazineLuizaRewards::Exceptions::BadRequestError,
+        expect { cart }.to raise_error(MagazineLuizaRewardsV2::Exceptions::BadRequestError,
                                        'Item Not Found')
       end
     end
@@ -41,7 +41,7 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
     let(:card_id) { '71555ff9-91c3-4264-9095-06a169117cb3' }
 
     context 'when successfull', vcr: { cassette_name: 'carts/get_successful' } do
-      it { expect(cart).to be_a(MagazineLuizaRewards::Cart) }
+      it { expect(cart).to be_a(MagazineLuizaRewardsV2::Cart) }
       it { expect(cart.items.first.sku).to eq('200487300') }
       it { expect(cart.items.first.seller).to eq('magazineluiza') }
       it { expect(cart.items.first.quantity).to eq(1) }
@@ -54,7 +54,7 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
 
       it do
         expect { cart }.to \
-          raise_error(MagazineLuizaRewards::Exceptions::NotFoundError,
+          raise_error(MagazineLuizaRewardsV2::Exceptions::NotFoundError,
                       'The server did not find the requested resource in the request')
       end
     end
@@ -65,14 +65,14 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
 
     let(:card_id) { '71555ff9-91c3-4264-9095-06a169117cb3' }
     let(:cart) do
-      MagazineLuizaRewards::Cart.new(
+      MagazineLuizaRewardsV2::Cart.new(
         id: card_id,
         shipping_address_id: '61627000-81cb-4ee2-b90c-97eb35198301',
         customer_id: 'a6b461b7-09f4-4186-b700-040dfb72dd74',
         deliveries: [
-          MagazineLuizaRewards::PartialUpdateDeliveries.new(
+          MagazineLuizaRewardsV2::PartialUpdateDeliveries.new(
             id: '55956efe-ffba-41bf-a073-df43c4483d54-1',
-            modality: MagazineLuizaRewards::Modality.new(
+            modality: MagazineLuizaRewardsV2::Modality.new(
               id: '1',
               type: 'conventional'
             )
@@ -82,7 +82,7 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
     end
 
     context 'when successfull', vcr: { cassette_name: 'carts/update_successful' } do
-      it { expect(update).to be_a(MagazineLuizaRewards::Cart) }
+      it { expect(update).to be_a(MagazineLuizaRewardsV2::Cart) }
       it { expect(update.shipping_address_id).to eq('61627000-81cb-4ee2-b90c-97eb35198301') }
       it { expect(update.customer_id).to eq('a6b461b7-09f4-4186-b700-040dfb72dd74') }
       it { expect(update.billing_address_id).to eq('61627000-81cb-4ee2-b90c-97eb35198301') }
@@ -93,7 +93,7 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
 
       it do
         expect { update }.to \
-          raise_error(MagazineLuizaRewards::Exceptions::NotFoundError,
+          raise_error(MagazineLuizaRewardsV2::Exceptions::NotFoundError,
                       'The server did not find the requested resource in the request')
       end
     end
@@ -105,11 +105,11 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
     let(:card_id) { '71555ff9-91c3-4264-9095-06a169117cb3' }
     let(:sku) { '145855500' }
     let(:item) do
-      MagazineLuizaRewards::CartItem.new(sku: sku, seller: 'magazineluiza', quantity: 1)
+      MagazineLuizaRewardsV2::CartItem.new(sku: sku, seller: 'magazineluiza', quantity: 1)
     end
 
     context 'when successfull', vcr: { cassette_name: 'carts/add_item_successful' } do
-      it { expect(add_item).to be_a(MagazineLuizaRewards::Cart) }
+      it { expect(add_item).to be_a(MagazineLuizaRewardsV2::Cart) }
       it { expect(add_item.items.map(&:sku)).to include('145855500') }
     end
 
@@ -117,7 +117,7 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
       let(:sku) { 'invalid' }
 
       it do
-        expect { add_item }.to raise_error(MagazineLuizaRewards::Exceptions::BadRequestError,
+        expect { add_item }.to raise_error(MagazineLuizaRewardsV2::Exceptions::BadRequestError,
                                            'Item Not Found')
       end
     end
@@ -127,7 +127,7 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
 
       it do
         expect { add_item }.to \
-          raise_error(MagazineLuizaRewards::Exceptions::NotFoundError,
+          raise_error(MagazineLuizaRewardsV2::Exceptions::NotFoundError,
                       'The server did not find the requested resource in the request')
       end
     end
@@ -139,12 +139,12 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
     let(:card_id) { '71555ff9-91c3-4264-9095-06a169117cb3' }
     let(:sku) { '200487300' }
     let(:item) do
-      MagazineLuizaRewards::CartItem.new(sku: sku, seller: 'magazineluiza', quantity: 2)
+      MagazineLuizaRewardsV2::CartItem.new(sku: sku, seller: 'magazineluiza', quantity: 2)
     end
     let(:updated_item) { update_item_quantity.items.find { |i| i.sku == sku } }
 
     context 'when successfull', vcr: { cassette_name: 'carts/update_item_quantity_successful' } do
-      it { expect(update_item_quantity).to be_a(MagazineLuizaRewards::Cart) }
+      it { expect(update_item_quantity).to be_a(MagazineLuizaRewardsV2::Cart) }
       it { expect(updated_item.quantity).to eq(2) }
     end
 
@@ -153,7 +153,7 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
 
       it do
         expect { update_item_quantity }.to \
-          raise_error(MagazineLuizaRewards::Exceptions::NotFoundError,
+          raise_error(MagazineLuizaRewardsV2::Exceptions::NotFoundError,
                       'Item Not Found')
       end
     end
@@ -164,7 +164,7 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
 
       it do
         expect { update_item_quantity }.to \
-          raise_error(MagazineLuizaRewards::Exceptions::NotFoundError,
+          raise_error(MagazineLuizaRewardsV2::Exceptions::NotFoundError,
                       'The server did not find the requested resource in the request')
       end
     end
@@ -176,11 +176,11 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
     let(:card_id) { '71555ff9-91c3-4264-9095-06a169117cb3' }
     let(:sku) { '200487300' }
     let(:item) do
-      MagazineLuizaRewards::CartItem.new(sku: sku, seller: 'magazineluiza')
+      MagazineLuizaRewardsV2::CartItem.new(sku: sku, seller: 'magazineluiza')
     end
 
     context 'when successfull', vcr: { cassette_name: 'carts/remove_item_successful' } do
-      it { expect(remove_item).to be_a(MagazineLuizaRewards::Cart) }
+      it { expect(remove_item).to be_a(MagazineLuizaRewardsV2::Cart) }
       it { expect(remove_item.items.map(&:sku)).not_to include('200487300') }
     end
 
@@ -188,7 +188,7 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
       let(:sku) { 'invalid' }
 
       it do
-        expect { remove_item }.to raise_error(MagazineLuizaRewards::Exceptions::NotFoundError,
+        expect { remove_item }.to raise_error(MagazineLuizaRewardsV2::Exceptions::NotFoundError,
                                               'Item Not Found')
       end
     end
@@ -198,7 +198,7 @@ RSpec.describe MagazineLuizaRewards::Api::Carts do
 
       it do
         expect { remove_item }.to \
-          raise_error(MagazineLuizaRewards::Exceptions::NotFoundError,
+          raise_error(MagazineLuizaRewardsV2::Exceptions::NotFoundError,
                       'The server did not find the requested resource in the request')
       end
     end

--- a/spec/lib/magazine_luiza_rewards/api/categories_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/api/categories_spec.rb
@@ -2,16 +2,16 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Api::Categories do
+RSpec.describe MagazineLuizaRewardsV2::Api::Categories do
   subject(:api_categories) { described_class.new(client) }
 
   let(:token) { 'fake-token' }
-  let(:client) { MagazineLuizaRewards::Client.new(token) }
+  let(:client) { MagazineLuizaRewardsV2::Client.new(token) }
 
   describe '#catgories', vcr: { cassette_name: 'categories/categories' } do
     subject(:categories) { api_categories.categories }
 
     it { expect(categories).to be_a(Array) }
-    it { expect(categories).to all(be_a(MagazineLuizaRewards::Category)) }
+    it { expect(categories).to all(be_a(MagazineLuizaRewardsV2::Category)) }
   end
 end

--- a/spec/lib/magazine_luiza_rewards/api/customers_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/api/customers_spec.rb
@@ -2,22 +2,22 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Api::Customers do
+RSpec.describe MagazineLuizaRewardsV2::Api::Customers do
   subject(:api_customers) { described_class.new(client) }
 
   let(:token) { 'fake-token' }
-  let(:client) { MagazineLuizaRewards::Client.new(token) }
+  let(:client) { MagazineLuizaRewardsV2::Client.new(token) }
 
   describe '#create' do
     subject(:create) { api_customers.create(customer) }
 
     let(:customer) do
-      MagazineLuizaRewards::Customer.new(
+      MagazineLuizaRewardsV2::Customer.new(
         name: 'John Doe',
         email: 'fulano@example.com',
         document: '33226126008',
         birth_date: '1990-01-01',
-        address: MagazineLuizaRewards::Address.new(
+        address: MagazineLuizaRewardsV2::Address.new(
           zip_code: '12345678',
           street: 'Rua dos Afagafinhos',
           district: 'Centro',
@@ -27,7 +27,7 @@ RSpec.describe MagazineLuizaRewards::Api::Customers do
           city: 'São Paulo',
           state: 'SP'
         ),
-        phone: MagazineLuizaRewards::Phone.new(
+        phone: MagazineLuizaRewardsV2::Phone.new(
           area_code: '11',
           number: '999999999'
         ),
@@ -44,12 +44,12 @@ RSpec.describe MagazineLuizaRewards::Api::Customers do
 
     context 'when not successful', vcr: { cassette_name: 'customers/unsuccessful' } do
       let(:customer) do
-        MagazineLuizaRewards::Customer.new(
+        MagazineLuizaRewardsV2::Customer.new(
           name: 'John Doe',
           email: 'fulano@example.com',
           document: '12345678901',
           birth_date: '1990-01-01',
-          address: MagazineLuizaRewards::Address.new(
+          address: MagazineLuizaRewardsV2::Address.new(
             zip_code: '12345678',
             street: 'Rua dos Afagafinhos',
             district: 'Centro',
@@ -59,7 +59,7 @@ RSpec.describe MagazineLuizaRewards::Api::Customers do
             city: 'São Paulo',
             state: 'SP'
           ),
-          phone: MagazineLuizaRewards::Phone.new(
+          phone: MagazineLuizaRewardsV2::Phone.new(
             area_code: '11',
             number: '999999999'
           ),
@@ -69,7 +69,7 @@ RSpec.describe MagazineLuizaRewards::Api::Customers do
       end
 
       it do
-        expect { create }.to raise_error(MagazineLuizaRewards::Exceptions::BadRequestError,
+        expect { create }.to raise_error(MagazineLuizaRewardsV2::Exceptions::BadRequestError,
                                          'INVALID DOCUMENT')
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe MagazineLuizaRewards::Api::Customers do
 
       it do
         expect { get }.to \
-          raise_error(MagazineLuizaRewards::Exceptions::NotFoundError,
+          raise_error(MagazineLuizaRewardsV2::Exceptions::NotFoundError,
                       'The server did not find the requested resource in the request')
       end
     end
@@ -101,7 +101,7 @@ RSpec.describe MagazineLuizaRewards::Api::Customers do
 
     let(:customer_id) { 'a6b461b7-09f4-4186-b700-040dfb72dd74' }
     let(:address_add) do
-      MagazineLuizaRewards::AddressAdd.new(
+      MagazineLuizaRewardsV2::AddressAdd.new(
         alias: 'Casa2',
         name: 'Fulano de Tal',
         zip_code: '12345678',
@@ -124,7 +124,7 @@ RSpec.describe MagazineLuizaRewards::Api::Customers do
 
     context 'when not successful', vcr: { cassette_name: 'customers/add_address_unsuccessful' } do
       let(:address_add) do
-        MagazineLuizaRewards::AddressAdd.new(
+        MagazineLuizaRewardsV2::AddressAdd.new(
           alias: 'Casa 3',
           name: '',
           zip_code: '',
@@ -142,7 +142,7 @@ RSpec.describe MagazineLuizaRewards::Api::Customers do
 
       it do
         expect { add_address }.to \
-          raise_error(MagazineLuizaRewards::Exceptions::UnprocessableEntityError,
+          raise_error(MagazineLuizaRewardsV2::Exceptions::UnprocessableEntityError,
                       'value is not a valid')
       end
     end
@@ -172,7 +172,7 @@ RSpec.describe MagazineLuizaRewards::Api::Customers do
 
       it do
         expect { get_address }.to \
-          raise_error(MagazineLuizaRewards::Exceptions::NotFoundError,
+          raise_error(MagazineLuizaRewardsV2::Exceptions::NotFoundError,
                       'The server did not find the requested resource in the request')
       end
     end

--- a/spec/lib/magazine_luiza_rewards/api/freight_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/api/freight_spec.rb
@@ -2,11 +2,11 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Api::Freight do
+RSpec.describe MagazineLuizaRewardsV2::Api::Freight do
   subject(:freight_api) { described_class.new(client) }
 
   let(:token) { 'fake-token' }
-  let(:client) { MagazineLuizaRewards::Client.new(token) }
+  let(:client) { MagazineLuizaRewardsV2::Client.new(token) }
 
   describe '#calculate' do
     subject(:calculated) { freight_api.calculate(zip_code, cart_id) }
@@ -15,7 +15,7 @@ RSpec.describe MagazineLuizaRewards::Api::Freight do
       let(:zip_code) { '14302536' }
       let(:cart_id) { '3a77f5a9-bb54-4f57-af63-145d517d4d22' }
 
-      it { expect(calculated).to be_a(MagazineLuizaRewards::CalculatedFreight) }
+      it { expect(calculated).to be_a(MagazineLuizaRewardsV2::CalculatedFreight) }
     end
 
     context 'when cart not found', vcr: { cassette_name: 'calculate_freight/not_found' } do
@@ -24,7 +24,7 @@ RSpec.describe MagazineLuizaRewards::Api::Freight do
 
       it do
         expect { calculated }.to \
-          raise_error(MagazineLuizaRewards::Exceptions::NotFoundError,
+          raise_error(MagazineLuizaRewardsV2::Exceptions::NotFoundError,
                       "Cart #{cart_id} does not exist")
       end
     end
@@ -39,10 +39,10 @@ RSpec.describe MagazineLuizaRewards::Api::Freight do
       let(:seller) { 'magazineluiza' }
       let(:delivery_type) { estimated.delivery_types.first }
 
-      it { expect(estimated).to be_a(MagazineLuizaRewards::EstimatedFreight) }
+      it { expect(estimated).to be_a(MagazineLuizaRewardsV2::EstimatedFreight) }
       it { expect(estimated.sku).to eq(sku) }
       it { expect(estimated.seller).to eq(seller) }
-      it { expect(estimated.delivery_types).to all(be_a(MagazineLuizaRewards::DeliveryType)) }
+      it { expect(estimated.delivery_types).to all(be_a(MagazineLuizaRewardsV2::DeliveryType)) }
       it { expect(delivery_type.type).to eq('conventional') }
       it { expect(delivery_type.time).to eq(7) }
       it { expect(delivery_type.description).to eq('Entrega padrão') }
@@ -57,7 +57,7 @@ RSpec.describe MagazineLuizaRewards::Api::Freight do
 
       it do
         expect { estimated }.to \
-          raise_error(MagazineLuizaRewards::Exceptions::NotFoundError,
+          raise_error(MagazineLuizaRewardsV2::Exceptions::NotFoundError,
                       'The server did not find the requested resource in the request')
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe MagazineLuizaRewards::Api::Freight do
 
       it do
         expect { estimated }.to \
-          raise_error(MagazineLuizaRewards::Exceptions::BadRequestError,
+          raise_error(MagazineLuizaRewardsV2::Exceptions::BadRequestError,
                       'Item not available to region')
       end
     end

--- a/spec/lib/magazine_luiza_rewards/api/orders_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/api/orders_spec.rb
@@ -2,23 +2,23 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Api::Orders do
+RSpec.describe MagazineLuizaRewardsV2::Api::Orders do
   subject(:order_api) { described_class.new(client) }
 
   let(:token) { 'fake-token' }
-  let(:client) { MagazineLuizaRewards::Client.new(token) }
+  let(:client) { MagazineLuizaRewardsV2::Client.new(token) }
 
   describe '#create' do
     subject(:order) { order_api.create(order_request) }
 
     let(:order_request) do
-      MagazineLuizaRewards::OrderRequest.new(
+      MagazineLuizaRewardsV2::OrderRequest.new(
         cart_id: 'd2d0408c-f03e-480a-9b95-1c6bcadbb873',
         customer_ip_address: '127.0.0.1',
         payment_method_id: 'external',
         installments: 1,
         partner_order_id: 'XYZ123',
-        shipping_reference_contact: MagazineLuizaRewards::ShippingContact.new(
+        shipping_reference_contact: MagazineLuizaRewardsV2::ShippingContact.new(
           phone_ddd: '16',
           phone_number: '99999999'
         )
@@ -26,19 +26,19 @@ RSpec.describe MagazineLuizaRewards::Api::Orders do
     end
 
     context 'when successfull', vcr: { cassette_name: 'orders/create_successful' } do
-      it { expect(order).to be_a(MagazineLuizaRewards::Order) }
+      it { expect(order).to be_a(MagazineLuizaRewardsV2::Order) }
       it { expect(order.customer_id).to eq('05940d85-a1b6-4652-9320-300f35ad9e8d') }
     end
 
     context 'when unsuccessfull', vcr: { cassette_name: 'orders/create_unsuccessful' } do
       let(:order_request) do
-        MagazineLuizaRewards::OrderRequest.new(
+        MagazineLuizaRewardsV2::OrderRequest.new(
           cart_id: 'd2d0408c-f03e-480a-9b95-1c6bcadbb872',
           customer_ip_address: '127.0.0.1',
           payment_method_id: 'external',
           installments: 1,
           partner_order_id: 'XYZ123',
-          shipping_reference_contact: MagazineLuizaRewards::ShippingContact.new(
+          shipping_reference_contact: MagazineLuizaRewardsV2::ShippingContact.new(
             phone_ddd: '16',
             phone_number: '99999999'
           )
@@ -47,7 +47,7 @@ RSpec.describe MagazineLuizaRewards::Api::Orders do
 
       it do
         expect { order }.to \
-          raise_error(MagazineLuizaRewards::Exceptions::NotFoundError,
+          raise_error(MagazineLuizaRewardsV2::Exceptions::NotFoundError,
                       'Cart d2d0408c-f03e-480a-9b95-1c6bcadbb872 does not exist')
       end
     end

--- a/spec/lib/magazine_luiza_rewards/api/products_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/api/products_spec.rb
@@ -2,11 +2,11 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Api::Products do
+RSpec.describe MagazineLuizaRewardsV2::Api::Products do
   subject(:api_products) { described_class.new(client) }
 
   let(:token) { 'fake-token' }
-  let(:client) { MagazineLuizaRewards::Client.new(token) }
+  let(:client) { MagazineLuizaRewardsV2::Client.new(token) }
 
   describe '#products' do
     subject(:products) { api_products.products(limit, page, filters) }
@@ -18,7 +18,7 @@ RSpec.describe MagazineLuizaRewards::Api::Products do
       let(:filters) { {} }
 
       it { expect(products).to be_a(Array) }
-      it { expect(products).to all(be_a(MagazineLuizaRewards::Product)) }
+      it { expect(products).to all(be_a(MagazineLuizaRewardsV2::Product)) }
       it { expect(products.size).to eq(10) }
     end
 
@@ -26,7 +26,7 @@ RSpec.describe MagazineLuizaRewards::Api::Products do
       let(:filters) { { brand: 'apple' } }
 
       it { expect(products).to be_a(Array) }
-      it { expect(products).to all(be_a(MagazineLuizaRewards::Product)) }
+      it { expect(products).to all(be_a(MagazineLuizaRewardsV2::Product)) }
       it { expect(products.map(&:brand)).to all(eq('Apple')) }
     end
   end
@@ -38,7 +38,7 @@ RSpec.describe MagazineLuizaRewards::Api::Products do
       let(:sku) { '229653300' }
       let(:seller) { 'magazineluiza' }
 
-      it { expect(product_info).to be_a(MagazineLuizaRewards::Product) }
+      it { expect(product_info).to be_a(MagazineLuizaRewardsV2::Product) }
       it { expect(product_info.sku).to eq(sku) }
       it { expect(product_info.seller_id).to eq(seller) }
     end
@@ -48,7 +48,7 @@ RSpec.describe MagazineLuizaRewards::Api::Products do
       let(:sku) { '999_999' }
       let(:seller) { 'unknown' }
 
-      it { expect { product_info }.to raise_error(MagazineLuizaRewards::Exceptions::NotFoundError) }
+      it { expect { product_info }.to raise_error(MagazineLuizaRewardsV2::Exceptions::NotFoundError) }
     end
   end
 
@@ -62,29 +62,29 @@ RSpec.describe MagazineLuizaRewards::Api::Products do
     context 'when product exists and show_payment_methods is false',
             vcr: { cassette_name: 'products/price_request_without_payment_methods' } do
       let(:product) do
-        MagazineLuizaRewards::Product.new(sku: '229653300', seller_id: 'magazineluiza')
+        MagazineLuizaRewardsV2::Product.new(sku: '229653300', seller_id: 'magazineluiza')
       end
 
       it { expect(pricing_and_availability).to be_a(Array) }
       it { expect(pricing_and_availability.size).to eq(1) }
-      it { expect(pricing_and_availability).to all(be_a(MagazineLuizaRewards::ProductPrice)) }
+      it { expect(pricing_and_availability).to all(be_a(MagazineLuizaRewardsV2::ProductPrice)) }
     end
 
     describe 'when product exists and show_payment_methods is true',
              vcr: { cassette_name: 'products/price_request_with_payment_methods' } do
       let(:show_payment_methods) { true }
       let(:product) do
-        MagazineLuizaRewards::Product.new(sku: '229653300', seller_id: 'magazineluiza')
+        MagazineLuizaRewardsV2::Product.new(sku: '229653300', seller_id: 'magazineluiza')
       end
 
       it { expect(pricing_and_availability).to be_a(Array) }
       it { expect(pricing_and_availability.size).to eq(1) }
-      it { expect(pricing_and_availability).to all(be_a(MagazineLuizaRewards::ProductPrice)) }
+      it { expect(pricing_and_availability).to all(be_a(MagazineLuizaRewardsV2::ProductPrice)) }
     end
 
     context 'when product does not exist',
             vcr: { cassette_name: 'products/price_not_found_request' } do
-      let(:product) { MagazineLuizaRewards::Product.new(sku: '999_999', seller_id: 'unknown') }
+      let(:product) { MagazineLuizaRewardsV2::Product.new(sku: '999_999', seller_id: 'unknown') }
 
       it { expect(pricing_and_availability).to be_a(Array) }
       it { expect(pricing_and_availability.size).to eq(0) }

--- a/spec/lib/magazine_luiza_rewards/client_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/client_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Client do
+RSpec.describe MagazineLuizaRewardsV2::Client do
   subject(:client) { described_class.new }
 
   describe '#initialize' do
@@ -16,13 +16,13 @@ RSpec.describe MagazineLuizaRewards::Client do
 
     let(:username) { 'user' }
     let(:password) { 'pass' }
-    let(:token_info) { instance_double(MagazineLuizaRewards::TokenInfo, access_token: 'abc') }
+    let(:token_info) { instance_double(MagazineLuizaRewardsV2::TokenInfo, access_token: 'abc') }
     let(:api) do
-      instance_double(MagazineLuizaRewards::Api::Authentication, generate_token: token_info)
+      instance_double(MagazineLuizaRewardsV2::Api::Authentication, generate_token: token_info)
     end
 
     before do
-      allow(MagazineLuizaRewards::Api::Authentication).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Authentication).to receive(:new).and_return(api)
       allow(api).to receive(:generate_token).with(username, password).and_return(token_info)
     end
 
@@ -41,10 +41,10 @@ RSpec.describe MagazineLuizaRewards::Client do
     let(:limit) { 10 }
     let(:page) { 1 }
     let(:filters) { {} }
-    let(:api) { instance_double(MagazineLuizaRewards::Api::Products, products: []) }
+    let(:api) { instance_double(MagazineLuizaRewardsV2::Api::Products, products: []) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Products).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Products).to receive(:new).and_return(api)
       allow(api).to receive(:products).with(limit, page, filters).and_return([])
     end
 
@@ -56,11 +56,11 @@ RSpec.describe MagazineLuizaRewards::Client do
 
     let(:sku) { '123' }
     let(:seller) { 'seller' }
-    let(:api) { instance_double(MagazineLuizaRewards::Api::Products, product_info: []) }
-    let(:product) { instance_double(MagazineLuizaRewards::Product) }
+    let(:api) { instance_double(MagazineLuizaRewardsV2::Api::Products, product_info: []) }
+    let(:product) { instance_double(MagazineLuizaRewardsV2::Product) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Products).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Products).to receive(:new).and_return(api)
       allow(api).to receive(:product_info).with(sku, seller).and_return(product)
     end
 
@@ -70,15 +70,15 @@ RSpec.describe MagazineLuizaRewards::Client do
   describe '#pricing_and_availability' do
     subject(:pricing_and_availability) { client.pricing_and_availability(products, **options) }
 
-    let(:products) { [MagazineLuizaRewards::Product.new(sku: '123', seller_id: 'seller')] }
+    let(:products) { [MagazineLuizaRewardsV2::Product.new(sku: '123', seller_id: 'seller')] }
     let(:options) { { show_payment_methods: false } }
-    let(:product_price) { instance_double(MagazineLuizaRewards::ProductPrice) }
+    let(:product_price) { instance_double(MagazineLuizaRewardsV2::ProductPrice) }
     let(:api) do
-      instance_double(MagazineLuizaRewards::Api::Products, pricing_and_availability: product_price)
+      instance_double(MagazineLuizaRewardsV2::Api::Products, pricing_and_availability: product_price)
     end
 
     before do
-      allow(MagazineLuizaRewards::Api::Products).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Products).to receive(:new).and_return(api)
       allow(api).to receive(:pricing_and_availability).with(products, **options)
                                                       .and_return(product_price)
     end
@@ -90,11 +90,11 @@ RSpec.describe MagazineLuizaRewards::Client do
     subject(:create_cart) { client.create_cart(items) }
 
     let(:items) { [] }
-    let(:api) { instance_double(MagazineLuizaRewards::Api::Carts, create_cart: []) }
-    let(:cart) { instance_double(MagazineLuizaRewards::Cart) }
+    let(:api) { instance_double(MagazineLuizaRewardsV2::Api::Carts, create_cart: []) }
+    let(:cart) { instance_double(MagazineLuizaRewardsV2::Cart) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Carts).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Carts).to receive(:new).and_return(api)
       allow(api).to receive(:create_cart).with(items).and_return(cart)
     end
 
@@ -105,11 +105,11 @@ RSpec.describe MagazineLuizaRewards::Client do
     subject(:get_cart) { client.get_cart(cart_id) }
 
     let(:cart_id) { '123' }
-    let(:api) { instance_double(MagazineLuizaRewards::Api::Carts, get_cart: []) }
-    let(:cart) { instance_double(MagazineLuizaRewards::Cart) }
+    let(:api) { instance_double(MagazineLuizaRewardsV2::Api::Carts, get_cart: []) }
+    let(:cart) { instance_double(MagazineLuizaRewardsV2::Cart) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Carts).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Carts).to receive(:new).and_return(api)
       allow(api).to receive(:get_cart).with(cart_id).and_return(cart)
     end
 
@@ -119,12 +119,12 @@ RSpec.describe MagazineLuizaRewards::Client do
   describe '#update_cart' do
     subject(:update_cart) { client.update_cart(cart) }
 
-    let(:cart) { instance_double(MagazineLuizaRewards::Cart) }
-    let(:api) { instance_double(MagazineLuizaRewards::Api::Carts, update_cart: []) }
-    let(:updated_cart) { instance_double(MagazineLuizaRewards::Cart) }
+    let(:cart) { instance_double(MagazineLuizaRewardsV2::Cart) }
+    let(:api) { instance_double(MagazineLuizaRewardsV2::Api::Carts, update_cart: []) }
+    let(:updated_cart) { instance_double(MagazineLuizaRewardsV2::Cart) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Carts).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Carts).to receive(:new).and_return(api)
       allow(api).to receive(:update_cart).with(cart).and_return(updated_cart)
     end
 
@@ -135,12 +135,12 @@ RSpec.describe MagazineLuizaRewards::Client do
     subject(:add_item_to_cart) { client.add_item_to_cart(cart_id, item) }
 
     let(:cart_id) { '123' }
-    let(:item) { instance_double(MagazineLuizaRewards::CartItem) }
-    let(:api) { instance_double(MagazineLuizaRewards::Api::Carts, add_item_to_cart: updated_cart) }
-    let(:updated_cart) { instance_double(MagazineLuizaRewards::Cart) }
+    let(:item) { instance_double(MagazineLuizaRewardsV2::CartItem) }
+    let(:api) { instance_double(MagazineLuizaRewardsV2::Api::Carts, add_item_to_cart: updated_cart) }
+    let(:updated_cart) { instance_double(MagazineLuizaRewardsV2::Cart) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Carts).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Carts).to receive(:new).and_return(api)
       allow(api).to receive(:add_item).with(cart_id, item).and_return(updated_cart)
     end
 
@@ -151,14 +151,14 @@ RSpec.describe MagazineLuizaRewards::Client do
     subject(:update_item_quantity) { client.update_item_quantity(cart_id, item) }
 
     let(:cart_id) { '123' }
-    let(:item) { instance_double(MagazineLuizaRewards::CartItem) }
+    let(:item) { instance_double(MagazineLuizaRewardsV2::CartItem) }
     let(:api) do
-      instance_double(MagazineLuizaRewards::Api::Carts, update_item_quantity: updated_cart)
+      instance_double(MagazineLuizaRewardsV2::Api::Carts, update_item_quantity: updated_cart)
     end
-    let(:updated_cart) { instance_double(MagazineLuizaRewards::Cart) }
+    let(:updated_cart) { instance_double(MagazineLuizaRewardsV2::Cart) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Carts).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Carts).to receive(:new).and_return(api)
       allow(api).to receive(:update_item_quantity).with(cart_id, item).and_return(updated_cart)
     end
 
@@ -169,14 +169,14 @@ RSpec.describe MagazineLuizaRewards::Client do
     subject(:remove_item_from_cart) { client.remove_item_from_cart(cart_id, item) }
 
     let(:cart_id) { '123' }
-    let(:item) { instance_double(MagazineLuizaRewards::CartItem) }
-    let(:updated_cart) { instance_double(MagazineLuizaRewards::Cart) }
+    let(:item) { instance_double(MagazineLuizaRewardsV2::CartItem) }
+    let(:updated_cart) { instance_double(MagazineLuizaRewardsV2::Cart) }
     let(:api) do
-      instance_double(MagazineLuizaRewards::Api::Carts, remove_item_from_cart: updated_cart)
+      instance_double(MagazineLuizaRewardsV2::Api::Carts, remove_item_from_cart: updated_cart)
     end
 
     before do
-      allow(MagazineLuizaRewards::Api::Carts).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Carts).to receive(:new).and_return(api)
       allow(api).to receive(:remove_item).with(cart_id, item).and_return(updated_cart)
     end
 
@@ -186,12 +186,12 @@ RSpec.describe MagazineLuizaRewards::Client do
   describe '#create_customer' do
     subject(:create_customer) { client.create_customer(customer) }
 
-    let(:customer) { instance_double(MagazineLuizaRewards::Customer) }
-    let(:api) { instance_double(MagazineLuizaRewards::Api::Customers, create_customer: []) }
-    let(:created_customer) { instance_double(MagazineLuizaRewards::Customer) }
+    let(:customer) { instance_double(MagazineLuizaRewardsV2::Customer) }
+    let(:api) { instance_double(MagazineLuizaRewardsV2::Api::Customers, create_customer: []) }
+    let(:created_customer) { instance_double(MagazineLuizaRewardsV2::Customer) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Customers).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Customers).to receive(:new).and_return(api)
       allow(api).to receive(:create_customer).with(customer).and_return(created_customer)
     end
 
@@ -202,11 +202,11 @@ RSpec.describe MagazineLuizaRewards::Client do
     subject(:get_customer) { client.get_customer(customer_id) }
 
     let(:customer_id) { '123' }
-    let(:api) { instance_double(MagazineLuizaRewards::Api::Customers, get_customer: []) }
-    let(:customer) { instance_double(MagazineLuizaRewards::Customer) }
+    let(:api) { instance_double(MagazineLuizaRewardsV2::Api::Customers, get_customer: []) }
+    let(:customer) { instance_double(MagazineLuizaRewardsV2::Customer) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Customers).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Customers).to receive(:new).and_return(api)
       allow(api).to receive(:get_customer).with(customer_id).and_return(customer)
     end
 
@@ -217,12 +217,12 @@ RSpec.describe MagazineLuizaRewards::Client do
     subject(:add_customer_address) { client.add_customer_address(customer_id, address) }
 
     let(:customer_id) { '123' }
-    let(:address) { instance_double(MagazineLuizaRewards::Address) }
-    let(:api) { instance_double(MagazineLuizaRewards::Api::Customers, add_customer_address: []) }
-    let(:customer) { instance_double(MagazineLuizaRewards::Customer) }
+    let(:address) { instance_double(MagazineLuizaRewardsV2::Address) }
+    let(:api) { instance_double(MagazineLuizaRewardsV2::Api::Customers, add_customer_address: []) }
+    let(:customer) { instance_double(MagazineLuizaRewardsV2::Customer) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Customers).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Customers).to receive(:new).and_return(api)
       allow(api).to receive(:add_customer_address).with(customer_id, address).and_return(customer)
     end
 
@@ -238,11 +238,11 @@ RSpec.describe MagazineLuizaRewards::Client do
     let(:number) { '456' }
     let(:street) { 'street' }
     let(:zip_code) { '789' }
-    let(:api) { instance_double(MagazineLuizaRewards::Api::Customers, get_customer_address: []) }
-    let(:address) { instance_double(MagazineLuizaRewards::Address) }
+    let(:api) { instance_double(MagazineLuizaRewardsV2::Api::Customers, get_customer_address: []) }
+    let(:address) { instance_double(MagazineLuizaRewardsV2::Address) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Customers).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Customers).to receive(:new).and_return(api)
       allow(api).to receive(:get_customer_address).with(customer_id, number, street, zip_code)
                                                   .and_return(address)
     end
@@ -256,11 +256,11 @@ RSpec.describe MagazineLuizaRewards::Client do
     let(:zip_code) { '123' }
     let(:sku) { '456' }
     let(:seller) { 'seller' }
-    let(:api) { instance_double(MagazineLuizaRewards::Api::Freight, estimate: []) }
-    let(:estimated_freight) { instance_double(MagazineLuizaRewards::EstimatedFreight) }
+    let(:api) { instance_double(MagazineLuizaRewardsV2::Api::Freight, estimate: []) }
+    let(:estimated_freight) { instance_double(MagazineLuizaRewardsV2::EstimatedFreight) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Freight).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Freight).to receive(:new).and_return(api)
       allow(api).to receive(:estimate_freight).with(zip_code, sku,
                                                     seller).and_return(estimated_freight)
     end
@@ -273,11 +273,11 @@ RSpec.describe MagazineLuizaRewards::Client do
 
     let(:zip_code) { '123' }
     let(:cart_id) { '456' }
-    let(:api) { instance_double(MagazineLuizaRewards::Api::Freight, calculate: []) }
-    let(:calculated_freight) { instance_double(MagazineLuizaRewards::CalculatedFreight) }
+    let(:api) { instance_double(MagazineLuizaRewardsV2::Api::Freight, calculate: []) }
+    let(:calculated_freight) { instance_double(MagazineLuizaRewardsV2::CalculatedFreight) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Freight).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Freight).to receive(:new).and_return(api)
       allow(api).to receive(:calculate_freight).with(zip_code, cart_id)
                                                .and_return(calculated_freight)
     end
@@ -288,11 +288,11 @@ RSpec.describe MagazineLuizaRewards::Client do
   describe '#categories' do
     subject(:categories) { client.categories }
 
-    let(:api) { instance_double(MagazineLuizaRewards::Api::Categories, categories: []) }
-    let(:category) { instance_double(MagazineLuizaRewards::Category) }
+    let(:api) { instance_double(MagazineLuizaRewardsV2::Api::Categories, categories: []) }
+    let(:category) { instance_double(MagazineLuizaRewardsV2::Category) }
 
     before do
-      allow(MagazineLuizaRewards::Api::Categories).to receive(:new).and_return(api)
+      allow(MagazineLuizaRewardsV2::Api::Categories).to receive(:new).and_return(api)
       allow(api).to receive(:categories).and_return([category])
     end
 

--- a/spec/lib/magazine_luiza_rewards/models/address_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/address_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Address do
+RSpec.describe MagazineLuizaRewardsV2::Address do
   describe 'attributes' do
     subject(:address) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/bank_slip_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/bank_slip_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::BankSlip do
+RSpec.describe MagazineLuizaRewardsV2::BankSlip do
   describe 'attributes' do
     subject(:bank_slip) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/best_price_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/best_price_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::BestPrice do
+RSpec.describe MagazineLuizaRewardsV2::BestPrice do
   describe 'attributes' do
     subject(:best_price) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/calculated_freight_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/calculated_freight_spec.rb
@@ -2,17 +2,17 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::CalculatedFreight do
+RSpec.describe MagazineLuizaRewardsV2::CalculatedFreight do
   describe 'attributes' do
     subject(:calculated_freight) { described_class }
 
     it { is_expected.to have_attribute(:disclaimers, Types::Array.of(Types::Coercible::String)) }
-    it { is_expected.to have_attribute(:deliveries, Types::Array.of(MagazineLuizaRewards::Delivery)) }
+    it { is_expected.to have_attribute(:deliveries, Types::Array.of(MagazineLuizaRewardsV2::Delivery)) }
 
     it do
       expect(calculated_freight).to \
         have_attribute(:unavailable_deliveries,
-                       Types::Array.of(MagazineLuizaRewards::UnavailableDelivery))
+                       Types::Array.of(MagazineLuizaRewardsV2::UnavailableDelivery))
     end
   end
 end

--- a/spec/lib/magazine_luiza_rewards/models/cart_item_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/cart_item_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::CartItem do
+RSpec.describe MagazineLuizaRewardsV2::CartItem do
   describe 'attributes' do
     subject(:cart_item) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/cart_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/cart_spec.rb
@@ -2,12 +2,12 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Cart do
+RSpec.describe MagazineLuizaRewardsV2::Cart do
   describe 'attributes' do
     subject(:cart) { described_class }
 
     it { is_expected.to have_attribute(:id, Types::Coercible::String) }
-    it { is_expected.to have_attribute(:items, Types::Array.of(MagazineLuizaRewards::CartItem)) }
+    it { is_expected.to have_attribute(:items, Types::Array.of(MagazineLuizaRewardsV2::CartItem)) }
     it { is_expected.to have_attribute(:promocode, Types::Coercible::String) }
     it { is_expected.to have_attribute(:total_amount, Types::Coercible::Decimal) }
     it { is_expected.to have_attribute(:total_best_amount, Types::Coercible::Decimal) }
@@ -17,7 +17,7 @@ RSpec.describe MagazineLuizaRewards::Cart do
 
     it do
       expect(cart).to \
-        have_attribute(:deliveries, Types::Array.of(MagazineLuizaRewards::PartialUpdateDeliveries))
+        have_attribute(:deliveries, Types::Array.of(MagazineLuizaRewardsV2::PartialUpdateDeliveries))
     end
   end
 end

--- a/spec/lib/magazine_luiza_rewards/models/category_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/category_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Category do
+RSpec.describe MagazineLuizaRewardsV2::Category do
   describe 'attributes' do
     subject(:category) { described_class }
 
@@ -11,7 +11,7 @@ RSpec.describe MagazineLuizaRewards::Category do
 
     it do
       expect(category).to have_attribute(:sub_categories,
-                                         Types::Array.of(MagazineLuizaRewards::SubCategory))
+                                         Types::Array.of(MagazineLuizaRewardsV2::SubCategory))
     end
   end
 end

--- a/spec/lib/magazine_luiza_rewards/models/customer_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/customer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Customer do
+RSpec.describe MagazineLuizaRewardsV2::Customer do
   describe 'attributes' do
     subject(:customer) { described_class }
 
@@ -10,8 +10,8 @@ RSpec.describe MagazineLuizaRewards::Customer do
     it { is_expected.to have_attribute(:email, Types::Coercible::String) }
     it { is_expected.to have_attribute(:document, Types::Coercible::String) }
     it { is_expected.to have_attribute(:birth_date, Types::Coercible::String) }
-    it { is_expected.to have_attribute(:address, MagazineLuizaRewards::Address) }
-    it { is_expected.to have_attribute(:phone, MagazineLuizaRewards::Phone) }
+    it { is_expected.to have_attribute(:address, MagazineLuizaRewardsV2::Address) }
+    it { is_expected.to have_attribute(:phone, MagazineLuizaRewardsV2::Phone) }
     it { is_expected.to have_attribute(:responsible_name, Types::Coercible::String.optional) }
     it { is_expected.to have_attribute(:state_inscription, Types::Coercible::String.optional) }
   end

--- a/spec/lib/magazine_luiza_rewards/models/delivery_item_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/delivery_item_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::DeliveryItem do
+RSpec.describe MagazineLuizaRewardsV2::DeliveryItem do
   describe 'attributes' do
     subject(:delivery_item) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/delivery_modality_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/delivery_modality_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::DeliveryModality do
+RSpec.describe MagazineLuizaRewardsV2::DeliveryModality do
   describe 'attributes' do
     subject(:delivery_modality) { described_class }
 
@@ -11,6 +11,6 @@ RSpec.describe MagazineLuizaRewards::DeliveryModality do
     it { is_expected.to have_attribute(:amount, Types::Coercible::Decimal) }
     it { is_expected.to have_attribute(:type, Types::Coercible::String) }
     it { is_expected.to have_attribute(:providers, Types::Array.of(Types::Coercible::String)) }
-    it { is_expected.to have_attribute(:shipping_time, MagazineLuizaRewards::ShippingTimeResponse) }
+    it { is_expected.to have_attribute(:shipping_time, MagazineLuizaRewardsV2::ShippingTimeResponse) }
   end
 end

--- a/spec/lib/magazine_luiza_rewards/models/delivery_parameters_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/delivery_parameters_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::DeliveryParameters do
+RSpec.describe MagazineLuizaRewardsV2::DeliveryParameters do
   describe 'attributes' do
     subject(:delivery_parameters) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/delivery_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/delivery_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Delivery do
+RSpec.describe MagazineLuizaRewardsV2::Delivery do
   describe 'attributes' do
     subject(:delivery) { described_class }
 
@@ -13,12 +13,12 @@ RSpec.describe MagazineLuizaRewards::Delivery do
 
     it do
       expect(delivery).to have_attribute(:items,
-                                         Types::Array.of(MagazineLuizaRewards::DeliveryItem))
+                                         Types::Array.of(MagazineLuizaRewardsV2::DeliveryItem))
     end
 
     it do
       expect(delivery).to have_attribute(:modalities,
-                                         Types::Array.of(MagazineLuizaRewards::DeliveryModality))
+                                         Types::Array.of(MagazineLuizaRewardsV2::DeliveryModality))
     end
   end
 end

--- a/spec/lib/magazine_luiza_rewards/models/delivery_type_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/delivery_type_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::DeliveryType do
+RSpec.describe MagazineLuizaRewardsV2::DeliveryType do
   describe 'attributes' do
     subject(:delivery_type) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/factsheet_element_element_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/factsheet_element_element_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::FactsheetElementElement do
+RSpec.describe MagazineLuizaRewardsV2::FactsheetElementElement do
   describe 'attributes' do
     subject { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/factsheet_element_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/factsheet_element_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::FactsheetElement do
+RSpec.describe MagazineLuizaRewardsV2::FactsheetElement do
   describe 'attributes' do
     subject(:element) { described_class }
 
@@ -13,7 +13,7 @@ RSpec.describe MagazineLuizaRewards::FactsheetElement do
     it do
       expect(element).to have_attribute(:elements,
                                         Types::Array.of(
-                                          MagazineLuizaRewards::FactsheetElementElement
+                                          MagazineLuizaRewardsV2::FactsheetElementElement
                                         ))
     end
   end

--- a/spec/lib/magazine_luiza_rewards/models/factsheet_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/factsheet_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Factsheet do
+RSpec.describe MagazineLuizaRewardsV2::Factsheet do
   describe 'attributes' do
     subject(:factsheet) { described_class }
 
@@ -12,7 +12,7 @@ RSpec.describe MagazineLuizaRewards::Factsheet do
 
     it do
       expect(factsheet).to have_attribute(:elements,
-                                          Types::Array.of(MagazineLuizaRewards::FactsheetElement))
+                                          Types::Array.of(MagazineLuizaRewardsV2::FactsheetElement))
     end
   end
 end

--- a/spec/lib/magazine_luiza_rewards/models/installment_plans_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/installment_plans_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::InstallmentPlans do
+RSpec.describe MagazineLuizaRewardsV2::InstallmentPlans do
   describe 'attributes' do
     subject(:installment_plans) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/modality_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/modality_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Modality do
+RSpec.describe MagazineLuizaRewardsV2::Modality do
   describe 'attributes' do
     subject(:modality) { described_class }
 
@@ -11,7 +11,7 @@ RSpec.describe MagazineLuizaRewards::Modality do
 
     it do
       expect(modality).to have_attribute(:delivery_parameters,
-                                         MagazineLuizaRewards::DeliveryParameters)
+                                         MagazineLuizaRewardsV2::DeliveryParameters)
     end
   end
 end

--- a/spec/lib/magazine_luiza_rewards/models/order_item_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/order_item_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::OrderItem do
+RSpec.describe MagazineLuizaRewardsV2::OrderItem do
   describe 'attributes' do
     subject(:order_item) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/order_payment_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/order_payment_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::OrderPayment do
+RSpec.describe MagazineLuizaRewardsV2::OrderPayment do
   describe 'attributes' do
     subject(:order_payment) { described_class }
 
@@ -20,6 +20,6 @@ RSpec.describe MagazineLuizaRewards::OrderPayment do
     it { is_expected.to have_attribute(:payment_url, Types::Coercible::String) }
     it { is_expected.to have_attribute(:emv_response, Types::Coercible::String) }
     it { is_expected.to have_attribute(:gateway_status_code, Types::Coercible::String) }
-    it { is_expected.to have_attribute(:pix, MagazineLuizaRewards::Pix) }
+    it { is_expected.to have_attribute(:pix, MagazineLuizaRewardsV2::Pix) }
   end
 end

--- a/spec/lib/magazine_luiza_rewards/models/order_request_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/order_request_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::OrderRequest do
+RSpec.describe MagazineLuizaRewardsV2::OrderRequest do
   describe 'attributes' do
     subject(:order_request) { described_class }
 
@@ -11,11 +11,11 @@ RSpec.describe MagazineLuizaRewards::OrderRequest do
     it { is_expected.to have_attribute(:payment_method_id, Types::Coercible::String) }
     it { is_expected.to have_attribute(:installments, Types::Coercible::Integer) }
     it { is_expected.to have_attribute(:partner_order_id, Types::Coercible::String) }
-    it { is_expected.to have_attribute(:payment_info, MagazineLuizaRewards::PaymentInfo) }
+    it { is_expected.to have_attribute(:payment_info, MagazineLuizaRewardsV2::PaymentInfo) }
 
     it do
       expect(order_request).to have_attribute(:shipping_reference_contact,
-                                              MagazineLuizaRewards::ShippingContact)
+                                              MagazineLuizaRewardsV2::ShippingContact)
     end
   end
 end

--- a/spec/lib/magazine_luiza_rewards/models/order_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/order_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Order do
+RSpec.describe MagazineLuizaRewardsV2::Order do
   describe 'attributes' do
     subject(:order) { described_class }
 
@@ -12,8 +12,8 @@ RSpec.describe MagazineLuizaRewards::Order do
     it { is_expected.to have_attribute(:product_total, Types::Coercible::Decimal) }
     it { is_expected.to have_attribute(:created_at, Types::Coercible::String) }
     it { is_expected.to have_attribute(:total_amount, Types::Coercible::Decimal) }
-    it { is_expected.to have_attribute(:payments, MagazineLuizaRewards::OrderPayment) }
-    it { is_expected.to have_attribute(:items, Types::Array.of(MagazineLuizaRewards::OrderItem)) }
+    it { is_expected.to have_attribute(:payments, MagazineLuizaRewardsV2::OrderPayment) }
+    it { is_expected.to have_attribute(:items, Types::Array.of(MagazineLuizaRewardsV2::OrderItem)) }
     it { is_expected.to have_attribute(:display_order_id, Types::Coercible::String) }
     it { is_expected.to have_attribute(:bank_slip, Types::Coercible::String) }
   end

--- a/spec/lib/magazine_luiza_rewards/models/package_item_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/package_item_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::PackageItem do
+RSpec.describe MagazineLuizaRewardsV2::PackageItem do
   describe 'attributes' do
     subject(:package_item) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/package_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/package_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Package do
+RSpec.describe MagazineLuizaRewardsV2::Package do
   describe 'attributes' do
     subject(:package) { described_class }
 
@@ -10,7 +10,7 @@ RSpec.describe MagazineLuizaRewards::Package do
     it { is_expected.to have_attribute(:delivery_time, Types::Coercible::String) }
     it { is_expected.to have_attribute(:delivery_type_id, Types::Coercible::String) }
     it { is_expected.to have_attribute(:delivery_type_description, Types::Coercible::String) }
-    it { is_expected.to have_attribute(:items, Types::Array.of(MagazineLuizaRewards::PackageItem)) }
+    it { is_expected.to have_attribute(:items, Types::Array.of(MagazineLuizaRewardsV2::PackageItem)) }
     it { is_expected.to have_attribute(:seller, Types::Coercible::String) }
     it { is_expected.to have_attribute(:package_id, Types::Coercible::String) }
   end

--- a/spec/lib/magazine_luiza_rewards/models/partial_update_deliveries_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/partial_update_deliveries_spec.rb
@@ -2,11 +2,11 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::PartialUpdateDeliveries do
+RSpec.describe MagazineLuizaRewardsV2::PartialUpdateDeliveries do
   describe 'attributes' do
     subject(:partial_update_deliveries) { described_class }
 
     it { is_expected.to have_attribute(:id, Types::Coercible::String) }
-    it { is_expected.to have_attribute(:modality, MagazineLuizaRewards::Modality) }
+    it { is_expected.to have_attribute(:modality, MagazineLuizaRewardsV2::Modality) }
   end
 end

--- a/spec/lib/magazine_luiza_rewards/models/payment_info_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/payment_info_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::PaymentInfo do
+RSpec.describe MagazineLuizaRewardsV2::PaymentInfo do
   describe 'attributes' do
     subject(:payment_info) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/payment_methods_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/payment_methods_spec.rb
@@ -2,12 +2,12 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::PaymentMethods do
+RSpec.describe MagazineLuizaRewardsV2::PaymentMethods do
   describe 'attributes' do
     subject(:payment_methods) { described_class }
 
     it { is_expected.to have_attribute(:id, Types::Coercible::String) }
     it { is_expected.to have_attribute(:description, Types::Coercible::String) }
-    it { is_expected.to have_attribute(:installment_plans, MagazineLuizaRewards::InstallmentPlans) }
+    it { is_expected.to have_attribute(:installment_plans, MagazineLuizaRewardsV2::InstallmentPlans) }
   end
 end

--- a/spec/lib/magazine_luiza_rewards/models/phone_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/phone_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Phone do
+RSpec.describe MagazineLuizaRewardsV2::Phone do
   describe 'attributes' do
     subject(:phone) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/pix_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/pix_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Pix do
+RSpec.describe MagazineLuizaRewardsV2::Pix do
   describe 'attributes' do
     subject(:pix) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/product_attribute_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/product_attribute_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::ProductAttribute do
+RSpec.describe MagazineLuizaRewardsV2::ProductAttribute do
   describe 'attributes' do
     subject { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/product_bundle_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/product_bundle_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::ProductBundle do
+RSpec.describe MagazineLuizaRewardsV2::ProductBundle do
   describe 'attributes' do
     subject { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/product_dimension_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/product_dimension_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::ProductDimension do
+RSpec.describe MagazineLuizaRewardsV2::ProductDimension do
   describe 'attributes' do
     subject { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/product_price_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/product_price_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::ProductPrice do
+RSpec.describe MagazineLuizaRewardsV2::ProductPrice do
   describe 'attributes' do
     subject { described_class }
 
@@ -11,7 +11,7 @@ RSpec.describe MagazineLuizaRewards::ProductPrice do
     it { is_expected.to have_attribute(:availability, Types::Coercible::String) }
     it { is_expected.to have_attribute(:list_price, Types::Coercible::String) }
     it { is_expected.to have_attribute(:price, Types::Coercible::String) }
-    it { is_expected.to have_attribute(:best_price, MagazineLuizaRewards::BestPrice) }
-    it { is_expected.to have_attribute(:payment_methods, MagazineLuizaRewards::PaymentMethods) }
+    it { is_expected.to have_attribute(:best_price, MagazineLuizaRewardsV2::BestPrice) }
+    it { is_expected.to have_attribute(:payment_methods, MagazineLuizaRewardsV2::PaymentMethods) }
   end
 end

--- a/spec/lib/magazine_luiza_rewards/models/product_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/product_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::Product do
+RSpec.describe MagazineLuizaRewardsV2::Product do
   describe 'attributes' do
     subject(:product) { described_class }
 
@@ -27,26 +27,26 @@ RSpec.describe MagazineLuizaRewards::Product do
 
     it do
       expect(product).to have_attribute(:attributes,
-                                        Types::Array.of(MagazineLuizaRewards::ProductAttribute))
+                                        Types::Array.of(MagazineLuizaRewardsV2::ProductAttribute))
     end
 
     it do
-      expect(product).to have_attribute(:dimensions, MagazineLuizaRewards::ProductDimension)
+      expect(product).to have_attribute(:dimensions, MagazineLuizaRewardsV2::ProductDimension)
     end
 
     it do
       expect(product).to have_attribute(:bundles,
-                                        Types::Array.of(MagazineLuizaRewards::ProductBundle))
+                                        Types::Array.of(MagazineLuizaRewardsV2::ProductBundle))
     end
 
     it do
       expect(product).to have_attribute(:categories,
-                                        Types::Array.of(MagazineLuizaRewards::Category))
+                                        Types::Array.of(MagazineLuizaRewardsV2::Category))
     end
 
     it do
       expect(product).to have_attribute(:factsheet,
-                                        Types::Array.of(MagazineLuizaRewards::Factsheet))
+                                        Types::Array.of(MagazineLuizaRewardsV2::Factsheet))
     end
   end
 end

--- a/spec/lib/magazine_luiza_rewards/models/shipping_contact_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/shipping_contact_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::ShippingContact do
+RSpec.describe MagazineLuizaRewardsV2::ShippingContact do
   describe 'attributes' do
     subject(:shipping_contact) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/shipping_time_response_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/shipping_time_response_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::ShippingTimeResponse do
+RSpec.describe MagazineLuizaRewardsV2::ShippingTimeResponse do
   describe 'attributes' do
     subject(:shipping_time_response) { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/sub_category_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/sub_category_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::SubCategory do
+RSpec.describe MagazineLuizaRewardsV2::SubCategory do
   describe 'attributes' do
     subject { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/token_info_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/token_info_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::TokenInfo do
+RSpec.describe MagazineLuizaRewardsV2::TokenInfo do
   describe 'attributes' do
     subject { described_class }
 

--- a/spec/lib/magazine_luiza_rewards/models/unavailable_delivery_spec.rb
+++ b/spec/lib/magazine_luiza_rewards/models/unavailable_delivery_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe MagazineLuizaRewards::UnavailableDelivery do
+RSpec.describe MagazineLuizaRewardsV2::UnavailableDelivery do
   describe 'attributes' do
     subject(:unavailable_delivery) { described_class }
 
@@ -12,7 +12,7 @@ RSpec.describe MagazineLuizaRewards::UnavailableDelivery do
 
     it do
       expect(unavailable_delivery).to \
-        have_attribute(:items, Types::Array.of(MagazineLuizaRewards::DeliveryItem))
+        have_attribute(:items, Types::Array.of(MagazineLuizaRewardsV2::DeliveryItem))
     end
   end
 end

--- a/spec/magazine_luiza_rewards_spec.rb
+++ b/spec/magazine_luiza_rewards_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe MagazineLuizaRewards do
+RSpec.describe MagazineLuizaRewardsV2 do
   it 'has a version number' do
-    expect(MagazineLuizaRewards::VERSION).not_to be_nil
+    expect(MagazineLuizaRewardsV2::VERSION).not_to be_nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'magazine_luiza_rewards'
 require 'rspec/dry/struct'
 
-support_dir = "#{MagazineLuizaRewards.root}/spec/support/**/*.rb"
+support_dir = "#{MagazineLuizaRewardsV2.root}/spec/support/**/*.rb"
 Dir[support_dir].sort.each { |f| require f }
 
 RSpec.configure do |config|


### PR DESCRIPTION
#### What?

- add V2 in the module MagazineLuizaRewards

#### Why?

- to avoid name conflicts when use this gem in StarsPremium project
